### PR TITLE
Add local model host server with admin dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # aaw-serverdev
-Repository to do with all things AAW Server Related
+
+Prototype server for AAW AI code assistant running a local model.
+
+## Structure
+- `host_server/` – FastAPI application providing code analysis with key-based access and task scheduling.
+- `host_server/static/` – web GUIs for users (`index.html`) and admins (`admin.html`).
+- `requirements.txt` – Python dependencies.
+
+## Running
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Set allowed keys (comma separated) and optional concurrency:
+   ```bash
+   export ALLOWED_KEYS="demo-key"
+   export MAX_CONCURRENCY=2  # optional
+   ```
+3. Start the server:
+   ```bash
+   uvicorn host_server.main:app --reload
+   ```
+4. User interface: open [http://localhost:8000](http://localhost:8000).
+5. Admin dashboard: open [http://localhost:8000/admin](http://localhost:8000/admin) for resource usage and active users.
+
+The server loads a local Hugging Face model (`distilgpt2` by default) to analyze submitted code. Requests are queued via an internal semaphore so multiple users can be handled concurrently without manual intervention. An admin endpoint allows updating concurrency limits on the fly.

--- a/host_server/local_model.py
+++ b/host_server/local_model.py
@@ -1,0 +1,18 @@
+import os
+from functools import lru_cache
+from transformers import pipeline
+
+MODEL_NAME = os.getenv("MODEL_NAME", "distilgpt2")
+
+
+@lru_cache(maxsize=1)
+def get_pipeline():
+    return pipeline("text-generation", model=MODEL_NAME)
+
+
+def analyze_code(code: str) -> str:
+    pipe = get_pipeline()
+    prompt = f"Analyze the following code:\n{code}\nAnalysis:"
+    result = pipe(prompt, max_new_tokens=128)
+    generated = result[0]["generated_text"][len(prompt):]
+    return generated.strip()

--- a/host_server/main.py
+++ b/host_server/main.py
@@ -1,0 +1,97 @@
+import asyncio
+import os
+import subprocess
+import sys
+import time
+from typing import Dict
+
+
+def install_requirements() -> None:
+    req_path = os.path.join(
+        os.path.dirname(__file__), "..", "requirements.txt"
+    )
+    if os.path.exists(req_path):
+        subprocess.check_call(
+            [sys.executable, "-m", "pip", "install", "-r", req_path]
+        )
+
+
+try:
+    import psutil  # noqa: E402
+    from fastapi import FastAPI, HTTPException  # noqa: E402
+    from fastapi.responses import HTMLResponse  # noqa: E402
+    from fastapi.staticfiles import StaticFiles  # noqa: E402
+    from pydantic import BaseModel  # noqa: E402
+    from .local_model import analyze_code  # noqa: E402
+except ModuleNotFoundError:
+    install_requirements()
+    import psutil  # noqa: E402
+    from fastapi import FastAPI, HTTPException  # noqa: E402
+    from fastapi.responses import HTMLResponse  # noqa: E402
+    from fastapi.staticfiles import StaticFiles  # noqa: E402
+    from pydantic import BaseModel  # noqa: E402
+    from .local_model import analyze_code  # noqa: E402
+
+app = FastAPI(title="AAW Server AI")
+app.mount("/static", StaticFiles(directory="static"), name="static")
+
+ALLOWED_KEYS = [
+    key for key in os.getenv("ALLOWED_KEYS", "demo-key").split(",") if key
+]
+
+active_users: Dict[str, float] = {}
+concurrency_limit = int(os.getenv("MAX_CONCURRENCY", "1"))
+semaphore = asyncio.Semaphore(concurrency_limit)
+
+
+class CodeRequest(BaseModel):
+    key: str
+    code: str
+
+
+class ConcurrencyRequest(BaseModel):
+    limit: int
+
+
+@app.post("/analyze")
+async def analyze(req: CodeRequest):
+    if req.key not in ALLOWED_KEYS:
+        raise HTTPException(status_code=401, detail="Invalid key")
+    active_users[req.key] = time.time()
+    async with semaphore:
+        analysis = await asyncio.to_thread(analyze_code, req.code)
+    return {"analysis": analysis}
+
+
+@app.post("/concurrency")
+async def set_concurrency(req: ConcurrencyRequest):
+    global semaphore, concurrency_limit
+    concurrency_limit = max(1, req.limit)
+    semaphore = asyncio.Semaphore(concurrency_limit)
+    return {"limit": concurrency_limit}
+
+
+@app.get("/stats")
+async def stats():
+    process = psutil.Process()
+    cpu = psutil.cpu_percent()
+    memory = psutil.virtual_memory().percent
+    return {
+        "cpu": cpu,
+        "memory": memory,
+        "active_users": list(active_users.keys()),
+        "concurrency_limit": concurrency_limit,
+        "running_tasks": process.num_threads(),
+    }
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index():
+    with open("static/index.html", "r", encoding="utf-8") as f:
+        return HTMLResponse(f.read())
+
+
+@app.get("/admin", response_class=HTMLResponse)
+async def admin():
+    with open("static/admin.html", "r", encoding="utf-8") as f:
+        return HTMLResponse(f.read())

--- a/host_server/static/admin.html
+++ b/host_server/static/admin.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8"/>
+    <title>AAW Admin</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2rem; }
+    </style>
+</head>
+<body>
+    <h1>Server Stats</h1>
+    <div id="stats"></div>
+    <script>
+        async function load() {
+            const resp = await fetch('/stats');
+            if (resp.ok) {
+                const data = await resp.json();
+                document.getElementById('stats').innerText = JSON.stringify(data, null, 2);
+            }
+        }
+        load();
+        setInterval(load, 5000);
+    </script>
+</body>
+</html>

--- a/host_server/static/index.html
+++ b/host_server/static/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8"/>
+    <title>AAW Code Analyzer</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2rem; }
+        textarea { width: 100%; height: 200px; }
+        #output { white-space: pre-wrap; margin-top: 1rem; }
+    </style>
+</head>
+<body>
+    <h1>AAW Code Analyzer</h1>
+    <input type="text" id="key" placeholder="Access Key" />
+    <br/><br/>
+    <textarea id="code" placeholder="Paste your code here..."></textarea>
+    <br/>
+    <button onclick="analyze()">Analyze</button>
+    <div id="output"></div>
+    <script>
+        async function analyze() {
+            const key = document.getElementById('key').value;
+            const code = document.getElementById('code').value;
+            const resp = await fetch('/analyze', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ key, code })
+            });
+            if (!resp.ok) {
+                document.getElementById('output').innerText = 'Error: ' + resp.statusText;
+                return;
+            }
+            const data = await resp.json();
+            document.getElementById('output').innerText = data.analysis;
+        }
+    </script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn
+transformers
+torch
+psutil
+flake8
+pytest


### PR DESCRIPTION
## Summary
- Swap OpenAI usage for a local Hugging Face model with adjustable concurrency
- Expose admin dashboard showing resource usage and active users
- Document local model setup and scheduler controls
- Automatically install Python dependencies at runtime when launching the host server

## Testing
- `python -m py_compile host_server/main.py host_server/local_model.py`
- `flake8 host_server/main.py host_server/local_model.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688feeb2ec44833197b5af3e26a968f5