### PR TITLE
fix: support running main script standalone

### DIFF
--- a/host_server/main.py
+++ b/host_server/main.py
@@ -11,7 +11,10 @@ from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
-from .local_model import analyze_code
+try:
+    from .local_model import analyze_code
+except ImportError:  # Allows running as a script without a package context
+    from local_model import analyze_code
 
 BASE_DIR = Path(__file__).resolve().parent
 


### PR DESCRIPTION
## Summary
- allow `host_server/main.py` to run directly or as a module by falling back to absolute import

## Testing
- `pytest -q`
- `flake8 host_server`
- `python host_server/main.py`
- `python -m host_server.main`


------
https://chatgpt.com/codex/tasks/task_e_68905ade1db88331bdd11b530469c7ac